### PR TITLE
Added information in README for persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ $ docker build -t bitnami/mongodb-sharded:latest 'https://github.com/bitnami/bit
 
 If you remove the container all your data will be lost, and the next time you run the image the database will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed.
 
-For persistence you should mount a directory at the /bitnami/mongodb path.
-
-If the mounted directory is empty, it will be initialized on the first run. As this is a non-root container, the mounted files and directories must read/write permissions for the UID 1001
+For persistence you should mount a directory at the /bitnami/mongodb path. If the mounted directory is empty, it will be initialized on the first run. As this is a non-root container, the mounted files and directories must read/write permissions for the UID 1001
 
 ```console
 $ docker run \

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ $ docker build -t bitnami/mongodb-sharded:latest 'https://github.com/bitnami/bit
 
 If you remove the container all your data will be lost, and the next time you run the image the database will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed.
 
-For persistence you should mount a directory at the `/bitnami/mongodb` path. If the mounted directory is empty, it will be initialized on the first run.
+For persistence you should mount a directory at the /bitnami/mongodb path.
+
+If the mounted directory is empty, it will be initialized on the first run. As this is a non-root container, the mounted files and directories must read/write permissions for the UID 1001
 
 ```console
 $ docker run \
@@ -89,12 +91,24 @@ $ docker run \
 
 or by modifying the [`docker-compose.yml`](https://github.com/bitnami/bitnami-docker-mongodb-sharded/blob/master/docker-compose.yml) file present in this repository:
 
+- Create directories to hold the persistence data. At minimum you will need one directory for each mongo instance running in the sharded cluster. For example, that means one directory for mongos, mongocfg and mongoshard. You need to assign read write permission to UID 1001 (ie. mkdir [directory] && chown 1001:1001 [directory] && chmod 777 [directory]) to all directories.
+
 ```yaml
 services:
   mongodb-sharded:
   ...
     volumes:
-      - /path/to/mongodb-persistence:/bitnami
+      - /path/to/mongos-persistence:/bitnami
+  ...
+  mongodb-shard0:
+  ...
+    volumes:
+      - /path/to/mongoshard-persistence:/bitnami
+  ...
+  mongodb-cfg:
+  ...
+    volumes:
+      - /path/to/mongocfg-persistence:/bitnami
   ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ docker build -t bitnami/mongodb-sharded:latest 'https://github.com/bitnami/bit
 
 If you remove the container all your data will be lost, and the next time you run the image the database will be reinitialized. To avoid this loss of data, you should mount a volume that will persist even after the container is removed.
 
-For persistence you should mount a directory at the /bitnami/mongodb path. If the mounted directory is empty, it will be initialized on the first run. As this is a non-root container, the mounted files and directories must read/write permissions for the UID 1001
+For persistence you should create a directory and mount it at the /bitnami/mongodb path. If the mounted directory is empty, it will be initialized on the first run. As this is a non-root container, directory must have read/write permissions for the UID 1001.
 
 ```console
 $ docker run \


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Changed the README to add more details about the folders and permissions needed to persist the database using docker-compose.

**Benefits**

Clarifies how the directory structure/config for persistence.

**Possible drawbacks**

I did not test persistence using "docker run" and do not know if there are issues following the existing instructions. 

**Applicable issues**


**Additional information**


